### PR TITLE
adding a common env template file that we can all use to standardize …

### DIFF
--- a/source/template.env
+++ b/source/template.env
@@ -1,0 +1,24 @@
+# Source API: US Real Estate RapidAPI
+X-RapidAPI-Key=
+X-RapidAPI-Host=
+
+# Raw DB credentials - data imported from the Source API
+RAW_SERVER_NAME=
+RAW_DATABASE_NAME=
+RAW_USERNAME=
+RAW_PASSWORD=
+RAW_PORT=5432
+
+# Analytics DB credentials - contains data from our SQL queries
+ANALYTICS_SERVER_NAME=
+ANALYTICS_DATABASE_NAME=
+ANALYTICS_USERNAME=
+ANALYTICS_PASSWORD=
+ANALYTICS_PORT=5432
+
+# Logging DB credentials - contains pipeline metadata
+LOGGING_SERVER_NAME=
+LOGGING_DATABASE_NAME=
+LOGGING_USERNAME=
+LOGGING_PASSWORD=
+LOGGING_PORT=5432


### PR DESCRIPTION
…our credential naming

I added a template.env file for us to standardize our naming conventions for our API and database credentials.